### PR TITLE
added redgifs support to reddit ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -13,6 +13,7 @@ import com.rarchives.ripme.ripper.rippers.EromeRipper;
 import com.rarchives.ripme.ripper.rippers.ImgurRipper;
 import com.rarchives.ripme.ripper.rippers.VidbleRipper;
 import com.rarchives.ripme.ripper.rippers.GfycatRipper;
+import com.rarchives.ripme.ripper.rippers.RedgifsRipper;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
 import org.jsoup.Jsoup;
@@ -75,6 +76,17 @@ public class RipUtils {
                 logger.warn("Exception while retrieving gfycat page:", e);
             }
             return result;
+        }
+        else if (url.getHost().endsWith("redgifs.com")) {
+            try {
+                logger.debug("Fetching redgifs page " + url);
+                String videoURL = RedgifsRipper.getVideoURL(url);
+                logger.debug("Got redgifs URL: " + videoURL);
+                result.add(new URL(videoURL));
+            } catch ( IOException e ) {
+                // Do nothing
+                logger.warn("Exception while retrieving redgifs page:", e);
+            }
         }
         else if (url.toExternalForm().contains("vidble.com/album/") || url.toExternalForm().contains("vidble.com/show/")) {
             try {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [X] a style change/fix
* [ ] a new feature


# Description

I'm not sure what category this would fall in but my change adds support to redgifs links when ripping from a reddit profile. 

i.e. when ripping a reddit profile, it will pick up redgifs links.

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
